### PR TITLE
fix install on centos5, tested on 5.7 and 5.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,15 @@ ifndef NCONFIG
 		NCONFIG = ncursesw6-config
 	endif
 endif
-NLIBDIR = $(shell $(NCONFIG) --libdir)
-NINCLUDEDIR = $(shell $(NCONFIG) --includedir)
-NLIBS = $(shell $(NCONFIG) --libs) -lmenu
+
+ifdef NCONFIG
+    NLIBDIR = $(shell $(NCONFIG) --libdir)
+    NINCLUDEDIR = $(shell $(NCONFIG) --includedir)
+    NLIBS = $(shell $(NCONFIG) --libs) -lmenu
+else
+	NLIBS = -lncurses -lmenu
+endif
+
 ifneq ($(NLIBDIR),)
 	LIBDIR += -L$(NLIBDIR)
 endif

--- a/pgcenter.c
+++ b/pgcenter.c
@@ -10,6 +10,7 @@
 #include <getopt.h>
 #include <ifaddrs.h>
 #include <limits.h>
+#include <linux/types.h>
 #include <linux/ethtool.h>
 #include <linux/sockios.h>
 #include <menu.h>


### PR DESCRIPTION
There is no ncurses-config on centos5，fallback to the system default.
And in order to use '__u32' , we should include 'linux/types.h'.