### PR TITLE
Accept /proc/diskstat metrics with extra fields.

### DIFF
--- a/lib/stat/iostat.go
+++ b/lib/stat/iostat.go
@@ -94,7 +94,7 @@ func (c Diskstats) ReadLocal() error {
 		}
 		var ios = Diskstat{}
 
-		_, err = fmt.Sscanln(string(line),
+		_, err = fmt.Sscan(string(line),
 			&ios.Major, &ios.Minor, &ios.Device,
 			&ios.Rcompleted, &ios.Rmerged, &ios.Rsectors, &ios.Rspent,
 			&ios.Wcompleted, &ios.Wmerged, &ios.Wsectors, &ios.Wspent,


### PR DESCRIPTION
Kernels 4.18+ append 4 additional fields to /proc/diskstat output (see https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats), breaking the original code assumption of 14th fields only that was enforced by Sscanln.

The one-liner has been tested with Linux 4.20.7 and 4.4.0.