### PR TITLE
preserve spacing when collapsing multiline queries

### DIFF
--- a/lib/stat/queries.go
+++ b/lib/stat/queries.go
@@ -407,8 +407,8 @@ date_trunc('seconds', clock_timestamp() - query_start)::text AS query_age,
 date_trunc('seconds', clock_timestamp() - state_change)::text AS change_age,
 regexp_replace(
 regexp_replace(query,
-E'( |\t)+', ' ', 'g'),
-E'\n', '', 'g') AS query
+E'\n', ' ', 'g'),
+E'( |\t)+', ' ', 'g') AS query
 FROM pg_stat_activity
 {{ if .ShowNoIdle }}
 WHERE ((clock_timestamp() - xact_start) > '{{.QueryAgeThresh}}'::interval OR (clock_timestamp() - query_start) > '{{.QueryAgeThresh}}'::interval)
@@ -434,8 +434,8 @@ date_trunc('seconds', clock_timestamp() - query_start)::text AS query_age,
 date_trunc('seconds', clock_timestamp() - state_change)::text AS change_age,
 regexp_replace(
 regexp_replace(query,
-E'( |\t)+', ' ', 'g'),
-E'\n', '', 'g') AS query
+E'\n', ' ', 'g'),
+E'( |\t)+', ' ', 'g') AS query
 FROM pg_stat_activity
 {{ if .ShowNoIdle }}
 WHERE ((clock_timestamp() - xact_start) > '{{.QueryAgeThresh}}'::interval OR (clock_timestamp() - query_start) > '{{.QueryAgeThresh}}'::interval)
@@ -460,8 +460,8 @@ date_trunc('seconds', clock_timestamp() - query_start)::text AS query_age,
 date_trunc('seconds', clock_timestamp() - state_change)::text AS change_age,
 regexp_replace(
 regexp_replace(query,
-E'( |\t)+', ' ', 'g'),
-E'\n', '', 'g') AS query
+E'\n', ' ', 'g'),
+E'( |\t)+', ' ', 'g') AS query
 FROM pg_stat_activity
 {{ if .ShowNoIdle }}
 WHERE ((clock_timestamp() - xact_start) > '{{.QueryAgeThresh}}'::interval OR (clock_timestamp() - query_start) > '{{.QueryAgeThresh}}'::interval)


### PR DESCRIPTION
In `pgcenter top`, multiline queries are collapsed without regard to spacing, so the top query itself is rendered so (no space between `SELECT` and the first column):

```sql
SELECTpid,client_addr AS cl_addr,...
```

Switching the order of regexp_replaces and adding a space for `\n` instead of treating it as zero-width yields more readable and copy-pastable SQL:

```sql
SELECT pid, client_addr AS cl_addr,...
```