### PR TITLE
Add PostgreSQL 15-18 support and testing infrastructure

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -6,7 +6,7 @@ on: push
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: lesovsky/pgcenter-testing:0.0.8
+    container: lesovsky/pgcenter-testing:0.0.9
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,57 +3,109 @@ name: Release
 
 on:
   push:
-    branches: [ release ]
+    branches: [release]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: lesovsky/pgcenter-testing:0.0.6
+    container: lesovsky/pgcenter-testing:0.0.9
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Cache Go 1.25.10 binary
+        id: cache-go
+        uses: actions/cache@v4
+        with:
+          path: /opt/go
+          key: go-1.25.10-linux-amd64
+
+      - name: Install Go 1.25.10
+        if: steps.cache-go.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL https://dl.google.com/go/go1.25.10.linux-amd64.tar.gz -o /tmp/go.tar.gz
+          tar -xf /tmp/go.tar.gz -C /opt
+
+      - name: Setup Go symlinks
+        run: |
+          ln -sf /opt/go/bin/go /usr/local/bin/go
+          ln -sf /opt/go/bin/gofmt /usr/local/bin/gofmt
+          go version
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-1.25.10-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-1.25.10-
+
+      - name: Cache lint tools
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-lint-v2-golangci-gosec-govulncheck
+
+      - name: Install lint tools
+        run: |
+          test -f ~/go/bin/golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          test -f ~/go/bin/gosec        || go install github.com/securego/gosec/v2/cmd/gosec@latest
+          test -f ~/go/bin/govulncheck  || go install golang.org/x/vuln/cmd/govulncheck@latest
+          ln -sf ~/go/bin/golangci-lint /usr/local/bin/golangci-lint
+          ln -sf ~/go/bin/gosec         /usr/local/bin/gosec
+          ln -sf ~/go/bin/govulncheck   /usr/local/bin/govulncheck
+
       - name: Prepare test environment
         run: prepare-test-environment.sh
+
+      - name: Fix git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Run lint
         run: make lint
+
+      - name: Run vulnerability check
+        run: govulncheck ./...
+
       - name: Run test
         run: make test
+
       - name: Build
         run: make build
+
       - name: Install
         run: make install
+
       - name: Run E2E tests
         run: ./testing/e2e.sh
 
-  build:
+  release:
     runs-on: ubuntu-latest
     needs: test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Build image
-        run: make docker-build
-      - name: Log in to Docker Hub
-        run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push image to Docker Hub
-        run: make docker-push
 
-  goreleaser:
-    runs-on: ubuntu-latest
-    needs: [ test, build ]
-    steps:
-      - uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v2
+          go-version: "1.25"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          go-version: 1.16
-      - uses: goreleaser/goreleaser-action@v2
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,15 @@
+version: 2
+
 before:
   hooks:
-  - make dep
+    - make dep
 
 builds:
   - binary: pgcenter
     main: ./cmd
     goarch:
       - amd64
+      - arm64
     goos:
       - linux
     env:
@@ -19,6 +22,8 @@ builds:
 
 archives:
   - builds: [pgcenter]
+    formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 nfpms:
   - vendor: pgcenter
@@ -26,5 +31,18 @@ nfpms:
     maintainer: Alexey Lesovsky
     description: Command-line admin tool for observing and troubleshooting Postgres.
     license: BSD-3
-    formats: [ deb, rpm, apk ]
+    formats: [deb, rpm, apk]
     bindir: /usr/bin
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "Merge pull request"
+      - "Merge branch"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-# __release_tag__ golang 1.16 was released 2021-02-16
-# __release_tag__ alpine 3.13 was released 2021-01-14
-
 # stage 1: build
-FROM golang:1.16 as build
+FROM golang:1.25-alpine AS build
 LABEL stage=intermediate
 WORKDIR /app
 COPY . .
 RUN make build
 
-# stage 2: scratch
-FROM alpine:3.13 as scratch
+# stage 2: final image
+FROM alpine:3.21 AS final
+RUN apk --no-cache add ca-certificates
 COPY --from=build /app/bin/pgcenter /bin/pgcenter
 CMD ["pgcenter"]

--- a/internal/postgres/testing.go
+++ b/internal/postgres/testing.go
@@ -15,7 +15,8 @@ func NewTestConnect() (*DB, error) {
 // Callers should use t.Skip() when this returns an error for EOL versions.
 func NewTestConnectVersion(version int) (*DB, error) {
 	ports := map[int]int{
-		// active versions (available in pgcenter-testing:0.0.8+)
+		// active versions (available in pgcenter-testing:0.0.9+)
+		180000: 21918,
 		170000: 21917,
 		160000: 21916,
 		150000: 21915,

--- a/internal/query/activity_test.go
+++ b/internal/query/activity_test.go
@@ -26,7 +26,7 @@ func TestSelectStatActivityQuery(t *testing.T) {
 }
 
 func Test_StatActivityQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_activity/%d", version), func(t *testing.T) {

--- a/internal/query/activity_test.go
+++ b/internal/query/activity_test.go
@@ -26,7 +26,7 @@ func TestSelectStatActivityQuery(t *testing.T) {
 }
 
 func Test_StatActivityQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_activity/%d", version), func(t *testing.T) {

--- a/internal/query/common_test.go
+++ b/internal/query/common_test.go
@@ -61,7 +61,7 @@ func TestSelectActivityStatementsQuery(t *testing.T) {
 }
 
 func Test_CommonQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	queries := []struct {
 		query string

--- a/internal/query/common_test.go
+++ b/internal/query/common_test.go
@@ -61,7 +61,7 @@ func TestSelectActivityStatementsQuery(t *testing.T) {
 }
 
 func Test_CommonQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	queries := []struct {
 		query string

--- a/internal/query/databases_test.go
+++ b/internal/query/databases_test.go
@@ -31,7 +31,7 @@ func TestSelectStatDatabaseQuery(t *testing.T) {
 }
 
 func Test_SelectStatDatabaseGeneralQuery(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_database/general/%d", version), func(t *testing.T) {

--- a/internal/query/databases_test.go
+++ b/internal/query/databases_test.go
@@ -31,7 +31,7 @@ func TestSelectStatDatabaseQuery(t *testing.T) {
 }
 
 func Test_SelectStatDatabaseGeneralQuery(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_database/general/%d", version), func(t *testing.T) {

--- a/internal/query/functions_test.go
+++ b/internal/query/functions_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatFunctionsQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_user_functions/%d", version), func(t *testing.T) {

--- a/internal/query/functions_test.go
+++ b/internal/query/functions_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatFunctionsQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_user_functions/%d", version), func(t *testing.T) {

--- a/internal/query/indexes_test.go
+++ b/internal/query/indexes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatIndexesQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_indexes/%d", version), func(t *testing.T) {

--- a/internal/query/indexes_test.go
+++ b/internal/query/indexes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatIndexesQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_indexes/%d", version), func(t *testing.T) {

--- a/internal/query/pgcenter_schema_test.go
+++ b/internal/query/pgcenter_schema_test.go
@@ -18,7 +18,7 @@ func Test_QueryPgcenterSchema(t *testing.T) {
 		"SELECT * FROM pgcenter.sys_proc_mounts",
 	}
 
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("query-pgcenter-schema/%d", version), func(t *testing.T) {

--- a/internal/query/pgcenter_schema_test.go
+++ b/internal/query/pgcenter_schema_test.go
@@ -18,7 +18,7 @@ func Test_QueryPgcenterSchema(t *testing.T) {
 		"SELECT * FROM pgcenter.sys_proc_mounts",
 	}
 
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("query-pgcenter-schema/%d", version), func(t *testing.T) {

--- a/internal/query/progress_analyze_test.go
+++ b/internal/query/progress_analyze_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressAnalyzeQueries(t *testing.T) {
-	versions := []int{140000}
+	versions := []int{140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_analyze/%d", version), func(t *testing.T) {

--- a/internal/query/progress_analyze_test.go
+++ b/internal/query/progress_analyze_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressAnalyzeQueries(t *testing.T) {
-	versions := []int{140000, 150000, 160000, 170000}
+	versions := []int{140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_analyze/%d", version), func(t *testing.T) {

--- a/internal/query/progress_basebackup_test.go
+++ b/internal/query/progress_basebackup_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressBasebackupQueries(t *testing.T) {
-	versions := []int{140000}
+	versions := []int{140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_basebackup/%d", version), func(t *testing.T) {

--- a/internal/query/progress_basebackup_test.go
+++ b/internal/query/progress_basebackup_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressBasebackupQueries(t *testing.T) {
-	versions := []int{140000, 150000, 160000, 170000}
+	versions := []int{140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_basebackup/%d", version), func(t *testing.T) {

--- a/internal/query/progress_cluster_test.go
+++ b/internal/query/progress_cluster_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressClusterQueries(t *testing.T) {
-	versions := []int{120000, 130000, 140000}
+	versions := []int{120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_cluster/%d", version), func(t *testing.T) {

--- a/internal/query/progress_cluster_test.go
+++ b/internal/query/progress_cluster_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressClusterQueries(t *testing.T) {
-	versions := []int{120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_cluster/%d", version), func(t *testing.T) {

--- a/internal/query/progress_copy_test.go
+++ b/internal/query/progress_copy_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressCopyQueries(t *testing.T) {
-	versions := []int{140000, 150000, 160000, 170000}
+	versions := []int{140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_copy/%d", version), func(t *testing.T) {

--- a/internal/query/progress_copy_test.go
+++ b/internal/query/progress_copy_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressCopyQueries(t *testing.T) {
-	versions := []int{140000}
+	versions := []int{140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_copy/%d", version), func(t *testing.T) {

--- a/internal/query/progress_create_index_test.go
+++ b/internal/query/progress_create_index_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressCreateIndexQueries(t *testing.T) {
-	versions := []int{120000, 130000, 140000}
+	versions := []int{120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_create_index/%d", version), func(t *testing.T) {

--- a/internal/query/progress_create_index_test.go
+++ b/internal/query/progress_create_index_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressCreateIndexQueries(t *testing.T) {
-	versions := []int{120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_create_index/%d", version), func(t *testing.T) {

--- a/internal/query/progress_vacuum_test.go
+++ b/internal/query/progress_vacuum_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressVacuumQueries(t *testing.T) {
-	versions := []int{90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_vacuum/%d", version), func(t *testing.T) {

--- a/internal/query/progress_vacuum_test.go
+++ b/internal/query/progress_vacuum_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatProgressVacuumQueries(t *testing.T) {
-	versions := []int{90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_progress_vacuum/%d", version), func(t *testing.T) {

--- a/internal/query/replication_test.go
+++ b/internal/query/replication_test.go
@@ -36,7 +36,7 @@ func TestSelectStatReplicationQuery(t *testing.T) {
 }
 
 func Test_StatReplicationQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_replication/%d", version), func(t *testing.T) {

--- a/internal/query/replication_test.go
+++ b/internal/query/replication_test.go
@@ -36,7 +36,7 @@ func TestSelectStatReplicationQuery(t *testing.T) {
 }
 
 func Test_StatReplicationQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_replication/%d", version), func(t *testing.T) {

--- a/internal/query/sizes_test.go
+++ b/internal/query/sizes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatSizesQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("sizes/%d", version), func(t *testing.T) {

--- a/internal/query/sizes_test.go
+++ b/internal/query/sizes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatSizesQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("sizes/%d", version), func(t *testing.T) {

--- a/internal/query/statements_test.go
+++ b/internal/query/statements_test.go
@@ -27,7 +27,7 @@ func TestSelectStatStatementsTimingQuery(t *testing.T) {
 }
 
 func Test_StatStatementsQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	queries := []string{
 		PgStatStatementsGeneralDefault,
@@ -115,7 +115,7 @@ func TestSelectQueryReportQuery(t *testing.T) {
 }
 
 func Test_StatStatementsReportQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		tmpl := SelectQueryReportQuery(version)

--- a/internal/query/statements_test.go
+++ b/internal/query/statements_test.go
@@ -27,7 +27,7 @@ func TestSelectStatStatementsTimingQuery(t *testing.T) {
 }
 
 func Test_StatStatementsQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	queries := []string{
 		PgStatStatementsGeneralDefault,
@@ -115,7 +115,7 @@ func TestSelectQueryReportQuery(t *testing.T) {
 }
 
 func Test_StatStatementsReportQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		tmpl := SelectQueryReportQuery(version)

--- a/internal/query/tables_test.go
+++ b/internal/query/tables_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatTablesQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_tables/%d", version), func(t *testing.T) {

--- a/internal/query/tables_test.go
+++ b/internal/query/tables_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_StatTablesQueries(t *testing.T) {
-	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000}
+	versions := []int{90500, 90600, 100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_tables/%d", version), func(t *testing.T) {

--- a/internal/query/wal.go
+++ b/internal/query/wal.go
@@ -1,7 +1,7 @@
 package query
 
 const (
-	// PgStatWALDefault defines default query for getting WAL stats from pg_stat_wal.
+	// PgStatWALDefault defines query for pg_stat_wal (PG 14-17).
 	PgStatWALDefault = "SELECT 'WAL' AS source, " +
 		"(SELECT pg_size_pretty(count(1) * pg_size_bytes(current_setting('wal_segment_size'))) AS waldir_size  FROM pg_ls_waldir()) AS waldir_size, " +
 		`round(wal_bytes / 1024, 2) AS "wal,KiB", ` +
@@ -9,4 +9,22 @@ const (
 		`wal_write AS write, wal_sync AS sync, wal_write_time AS "write,ms", wal_sync_time AS "sync,ms", wal_buffers_full AS buffers_full, ` +
 		"date_trunc('seconds', now() - stats_reset)::text AS stats_age " +
 		"FROM pg_stat_wal"
+
+	// PgStatWALPG18 defines query for pg_stat_wal (PG 18+).
+	// wal_write, wal_sync, wal_write_time, wal_sync_time removed in PG 18.
+	PgStatWALPG18 = "SELECT 'WAL' AS source, " +
+		"(SELECT pg_size_pretty(count(1) * pg_size_bytes(current_setting('wal_segment_size'))) AS waldir_size  FROM pg_ls_waldir()) AS waldir_size, " +
+		`round(wal_bytes / 1024, 2) AS "wal,KiB", ` +
+		"wal_records AS records, wal_fpi AS fpi, " +
+		"wal_buffers_full AS buffers_full, " +
+		"date_trunc('seconds', now() - stats_reset)::text AS stats_age " +
+		"FROM pg_stat_wal"
 )
+
+// SelectStatWALQuery returns the proper query and column count for pg_stat_wal based on PG version.
+func SelectStatWALQuery(version int) (string, int) {
+	if version >= 180000 {
+		return PgStatWALPG18, 7
+	}
+	return PgStatWALDefault, 11
+}

--- a/internal/query/wal_test.go
+++ b/internal/query/wal_test.go
@@ -9,7 +9,7 @@ import (
 
 // Test_StatWALQueries tests query, executing it against all supported Postgres versions.
 func Test_StatWALQueries(t *testing.T) {
-	versions := []int{140000}
+	versions := []int{140000, 150000, 160000, 170000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_wal/%d", version), func(t *testing.T) {

--- a/internal/query/wal_test.go
+++ b/internal/query/wal_test.go
@@ -9,11 +9,11 @@ import (
 
 // Test_StatWALQueries tests query, executing it against all supported Postgres versions.
 func Test_StatWALQueries(t *testing.T) {
-	versions := []int{140000, 150000, 160000, 170000}
+	versions := []int{140000, 150000, 160000, 170000, 180000}
 
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("pg_stat_wal/%d", version), func(t *testing.T) {
-			tmpl := PgStatWALDefault
+			tmpl, _ := SelectStatWALQuery(version)
 
 			opts := NewOptions(version, "f", "off", 256, "public")
 			q, err := Format(tmpl, opts)

--- a/internal/view/view.go
+++ b/internal/view/view.go
@@ -303,6 +303,9 @@ func (v Views) Configure(opts query.Options) error {
 		case "statements_timings":
 			view.QueryTmpl = query.SelectStatStatementsTimingQuery(opts.Version)
 			v[k] = view
+		case "wal":
+			view.QueryTmpl, view.Ncols = query.SelectStatWALQuery(opts.Version)
+			v[k] = view
 		}
 	}
 

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -3,7 +3,7 @@
 # Go and lint tools are installed by CI, not bundled here
 FROM ubuntu:22.04
 
-LABEL version="0.0.8"
+LABEL version="0.0.9"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -24,7 +24,8 @@ RUN apt-get update && \
         postgresql-14 postgresql-plperl-14 \
         postgresql-15 postgresql-plperl-15 \
         postgresql-16 postgresql-plperl-16 \
-        postgresql-17 postgresql-plperl-17 && \
+        postgresql-17 postgresql-plperl-17 \
+        postgresql-18 postgresql-plperl-18 && \
     cpanm --notest Module::Build && \
     cpanm --notest Linux::Ethtool::Settings && \
     mkdir /usr/local/testing/ && \
@@ -34,4 +35,4 @@ RUN apt-get update && \
 COPY prepare-test-environment.sh /usr/local/bin/
 COPY fixtures.sql /usr/local/testing/
 
-CMD ["echo", "pgcenter-testing 0.0.8: PostgreSQL 14-17 on Ubuntu 22.04"]
+CMD ["echo", "pgcenter-testing 0.0.9: PostgreSQL 14-18 on Ubuntu 22.04"]

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -12,14 +12,14 @@ mkdir /tmp/pgcenter-e2e
 #
 # pgcenter record
 #
-for port in 21914 21915 21916 21917; do
+for port in 21914 21915 21916 21917 21918; do
   pgcenter record -i 1s -c 5 -h 127.0.0.1 -p $port -U postgres -d pgcenter_fixtures -f /tmp/pgcenter-e2e/pgcenter.stat.$port.tar
 done
 
 #
 # pgcenter report
 #
-for port in 21914 21915 21916 21917; do
+for port in 21914 21915 21916 21917 21918; do
   for arg in -A -R -D -T -I -S -F -Xm -Xg -Xi -Xt -Xl -Xw -Pv -Pc -Pi -Pa -Pb -Pz; do
     pgcenter report $arg -f /tmp/pgcenter-e2e/pgcenter.stat.$port.tar > /tmp/pgcenter-e2e/pgcenter.stat.$port.$arg.out
   done

--- a/testing/prepare-test-environment.sh
+++ b/testing/prepare-test-environment.sh
@@ -3,14 +3,14 @@
 set -e
 
 # Create clusters for versions that don't have one yet
-for v in 14 15 16 17; do
+for v in 14 15 16 17 18; do
   if ! pg_lsclusters | grep -q "^$v "; then
     pg_createcluster "$v" main
   fi
 done
 
 # Configure each cluster
-for v in 14 15 16 17; do
+for v in 14 15 16 17 18; do
   port="219${v}"
   datadir="/var/lib/postgresql/${v}/main"
 
@@ -38,12 +38,12 @@ EOF
 done
 
 # Start all instances
-for v in 14 15 16 17; do
+for v in 14 15 16 17 18; do
   pg_ctlcluster "$v" main start
 done
 
 # Wait for all instances to be ready
-for v in 14 15 16 17; do
+for v in 14 15 16 17 18; do
   port="219${v}"
   until pg_isready -h 127.0.0.1 -p "$port" -U postgres -t 5 -q; do
     echo "Waiting for PostgreSQL $v on port $port..."
@@ -51,13 +51,13 @@ for v in 14 15 16 17; do
 done
 
 # Install pgcenter schema
-for v in 14 15 16 17; do
+for v in 14 15 16 17 18; do
   port="219${v}"
   su - postgres -c "psql -h 127.0.0.1 -p $port -f /usr/local/testing/fixtures.sql"
 done
 
 # Final availability check
-for v in 14 15 16 17; do
+for v in 14 15 16 17 18; do
   port="219${v}"
   pg_isready -t 10 -h 127.0.0.1 -p "$port" -U postgres -d pgcenter_fixtures
 done

--- a/testing/prepare-test-environment.sh
+++ b/testing/prepare-test-environment.sh
@@ -1,48 +1,62 @@
 #!/bin/bash
 
-# copy configuration files into data directories
+set -e
+
+# Create clusters for versions that don't have one yet
 for v in 14 15 16 17; do
-  su - postgres -c "mv /etc/postgresql/${v}/main/postgresql.conf /var/lib/postgresql/${v}/main/"
+  if ! pg_lsclusters | grep -q "^$v "; then
+    pg_createcluster "$v" main
+  fi
 done
 
-# add extra configuration parameters
+# Configure each cluster
 for v in 14 15 16 17; do
   port="219${v}"
-  {
-    echo "listen_addresses = '*'
-port = $port
+  datadir="/var/lib/postgresql/${v}/main"
+
+  # Write runtime params into auto.conf (in data directory)
+  cat >> "${datadir}/postgresql.auto.conf" << EOF
+listen_addresses = '*'
+port = ${port}
 shared_buffers = 16MB
 ssl = on
 ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
 ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'
 logging_collector = on
 log_directory = '/var/log/postgresql'
-log_filename = 'postgresql-$v.log'
+log_filename = 'postgresql-${v}.log'
 track_io_timing = on
 track_functions = all
-shared_preload_libraries = 'pg_stat_statements'"
-  } >> /var/lib/postgresql/${v}/main/postgresql.auto.conf
+shared_preload_libraries = 'pg_stat_statements'
+EOF
 
-  {
-    echo "local all all              trust
-host all all 0.0.0.0/0 trust"
-  } > /etc/postgresql/${v}/main/pg_hba.conf
-
-  mkdir /var/lib/postgresql/${v}/main/conf.d
+  # Allow all local connections
+  cat > "/etc/postgresql/${v}/main/pg_hba.conf" << EOF
+local all all              trust
+host all all 0.0.0.0/0 trust
+EOF
 done
 
-# run main postgres
+# Start all instances
 for v in 14 15 16 17; do
-  su - postgres -c "/usr/lib/postgresql/${v}/bin/pg_ctl -w -t 30 -l /var/log/postgresql/startup-${v}.log -D /var/lib/postgresql/${v}/main start"
+  pg_ctlcluster "$v" main start
 done
 
-# install pgcenter schema
+# Wait for all instances to be ready
 for v in 14 15 16 17; do
   port="219${v}"
-  su - postgres -c "psql -p $port -f /usr/local/testing/fixtures.sql"
+  until pg_isready -h 127.0.0.1 -p "$port" -U postgres -t 5 -q; do
+    echo "Waiting for PostgreSQL $v on port $port..."
+  done
 done
 
-# check services availability
+# Install pgcenter schema
+for v in 14 15 16 17; do
+  port="219${v}"
+  su - postgres -c "psql -h 127.0.0.1 -p $port -f /usr/local/testing/fixtures.sql"
+done
+
+# Final availability check
 for v in 14 15 16 17; do
   port="219${v}"
   pg_isready -t 10 -h 127.0.0.1 -p "$port" -U postgres -d pgcenter_fixtures


### PR DESCRIPTION
## Summary

- pgcenter-testing:0.0.9: Ubuntu 22.04, PostgreSQL 14–18 (up from 14-17)
- Fix cluster initialization in Docker (Ubuntu 22.04 doesn't auto-create clusters)
- PG 15/16/17: fully compatible with existing queries, no code changes needed
- PG 18: fix `pg_stat_wal` — 4 columns removed (`wal_write`, `wal_sync`, `wal_write_time`, `wal_sync_time`)
  - Add `PgStatWALPG18` constant and `SelectStatWALQuery(version)` selector
  - Wire into `view.Configure()` for proper runtime selection
- All query tests extended to cover PG 15–18 versions
- EOL versions (PG 9.5–13) skip gracefully via `t.Skipf`

## Test plan

- [x] All 5 PG instances (14–18) accepting connections in test container
- [x] `make test` → all 15 packages green, Total coverage: 63.5%
- [x] CI passes with pgcenter-testing:0.0.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)